### PR TITLE
chore: optional `browserlist` config

### DIFF
--- a/lib/rules/tscompat.ts
+++ b/lib/rules/tscompat.ts
@@ -351,7 +351,6 @@ export const tscompat = createRule({
     },
     schema: {
       type: "array",
-      minItems: 1,
       items: [
         {
           type: "object",
@@ -360,7 +359,6 @@ export const tscompat = createRule({
               type: "array",
             },
           },
-          required: ["browserslist"],
           additionalProperties: false,
         },
       ],


### PR DESCRIPTION
The `queries` parameter of `browserslist` is optional. If `undefined` is passed, it will automatically find and load the configuration from `package.json` or `.browserslistrc`.

See:
https://github.com/browserslist/browserslist/blob/main/node.js
